### PR TITLE
Main page > "changelog" links diretcly to the changelog page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <li><a href="#downloads">
             <i18n>Downloads</i18n>
         </a></li>
-        <li><a href="#changelog">
+        <li><a href="changelog.html">
             <i18n>Changelog</i18n>
         </a></li>
         <li><a href="#limitations">


### PR DESCRIPTION
There is no reason of having a "changelog" menu entry pointing to an internal link that is just a link to the changelog page